### PR TITLE
Optimize NewShaHashFromStr.

### DIFF
--- a/shahash_test.go
+++ b/shahash_test.go
@@ -116,6 +116,13 @@ func TestNewShaHashFromStr(t *testing.T) {
 			nil,
 		},
 
+		// Empty string.
+		{
+			"",
+			btcwire.ShaHash{},
+			nil,
+		},
+
 		// Single digit hash.
 		{
 			"1",


### PR DESCRIPTION
I can provide benchmark data if wanted, but it's rather dependant on the byte length of the string passed in (between 0 and 64 bytes).